### PR TITLE
Force unmount in OS X

### DIFF
--- a/build/umount.js
+++ b/build/umount.js
@@ -65,7 +65,7 @@ exports.umount = function(device, options, callback) {
   }
   _.defaults(options, settings);
   if (utils.isMacOSX()) {
-    unmountCommand = '/usr/sbin/diskutil unmountDisk';
+    unmountCommand = '/usr/sbin/diskutil unmountDisk force';
     options.noSudo = true;
   } else {
     unmountCommand = 'umount';

--- a/lib/umount.coffee
+++ b/lib/umount.coffee
@@ -58,7 +58,7 @@ exports.umount = (device, options = {}, callback) ->
 	_.defaults(options, settings)
 
 	if utils.isMacOSX()
-		unmountCommand = '/usr/sbin/diskutil unmountDisk'
+		unmountCommand = '/usr/sbin/diskutil unmountDisk force'
 
 		# OS X doesn't require `sudo` to unmount disks
 		options.noSudo = true

--- a/tests/umount.spec.coffee
+++ b/tests/umount.spec.coffee
@@ -104,7 +104,7 @@ describe 'Umount:', ->
 						expect(stdout).to.equal('stdout')
 						expect(stderr).to.equal('stderr')
 						expect(@childProcessExecStub).to.have.been.calledOnce
-						expect(@childProcessExecStub).to.have.been.calledWith('/usr/sbin/diskutil unmountDisk /dev/disk2')
+						expect(@childProcessExecStub).to.have.been.calledWith('/usr/sbin/diskutil unmountDisk force /dev/disk2')
 						done()
 
 			describe 'given is linux', ->


### PR DESCRIPTION
Prevents casual `at least one volume could not be unmounted` errors.

Signed-off-by: Juan Cruz Viotti <jviotti@openmailbox.org>